### PR TITLE
feat: add task crud, filter tasks, pagination and alerts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,156 @@
-# to-do-list
-To-do list app
+## <center>TO DO LIST APP</center>
+
+To-do list app is an application where you can create tasks, to check them as done, filter them by time created, title, is completed.
+
+You can log in with your email and the tasks will be associated with your email address. 
+
+--- 
+### Summary
+---
+
+* [**TECHNOLOGIES**](#technologies) 
+    > Defines the technologies used
+
+* [**ENVIRONMENT VARIABLE**](#environment-variable)
+    > Define .env file
+
+* [**RUN APP**](#run-app)
+    > Define how to run
+
+* [**FILE STRUCTURE**](#file-structure)
+    > Define the structure
+
+* [**Endpoints**](#endpoints)
+    > Define the endpoints
+
+
+<a id="technologies"></a> 
+
+### **TECHNOLOGIES**
+
+* **Vite**
+
+    * This project was created with vite, with the command:
+
+        `npm create vite@latest`
+        
+<br>
+
+* **bootstrap-icons:** to insert icons
+    * Added classes for custom color and size
+        ```jsx
+            <i className="bi bi-caret-right icon-larger secondary-color" />
+
+* **react-tooltip:** to add tooltips to icons
+
+    ```jsx
+        import { Tooltip } from 'react-tooltip'
+        
+        <i 
+            data-tooltip-id="create"
+            data-tooltip-content="Add a task"
+            className="bi bi-plus-circle-fill" 
+        />
+        <Tooltip id="create" />
+
+* **zustand:** to manage the status
+    * useStore:
+
+        ```js
+            const useStore = create((set) => ({
+                token: '',
+                updateToken: (newToken) => set({ token: newToken }),
+
+                user_email: '',
+                updateUserEmail: (newUserEmail) => set({ user_email: newUserEmail }),
+                
+                removeAll: () => set({ 
+                    user_email: '',
+                    token: ''
+                })
+            }))
+    
+    * Import:
+
+        ```js
+        import useStore from '../store/useStore';
+        const { updateToken, updateUserEmail, token, user-email, removeAll } = useStore()
+
+* **react-router-dom:** to manage the routes
+
+    ```jsx
+        import { BrowserRouter, Routes, Route } from "react-router-dom";
+
+        <BrowserRouter>
+            <Routes>
+                <Route path='/' element={<LogIn />}/>
+                <Route path='/to-do' element={<ListOfToDo />}/>
+            </Routes>
+        </BrowserRouter>
+
+* **sweetalert2:** to show alerts
+
+    ```js
+        Swal.fire({
+            title: 'Error!',
+            text: 'Invalid email',
+            icon: 'error',
+            confirmButtonText: 'Ok',
+            confirmButtonColor: '#F76C6A',
+            background: '#2A2A2A',
+            color: '#F79E89',
+            iconColor: '#F76C6A'
+        })
+
+<br>
+
+<a id="environment-variable"></a>
+### **ENVIRONMENT VARIABLE**
+
+* To facilitate the management of the API base URL, an environment variable was used
+
+    * .env
+
+        `VITE_API_BASE_URL=https://gsi-interviews.camiapp.net/to-do/`
+
+    * Import
+        `const apiUrl = import.meta.env.VITE_API_BASE_URL`
+
+<br>
+
+<a id="Run app"></a>
+### Run app
+
+* install the dependencies
+
+    `npm install`
+
+* run
+
+    `npm run dev`
+
+<br>
+
+<a id="file-structure"></a>
+### File structure
+
+* All the code is inside the src folder
+* inside we find the following folders
+    * components: all reusable components
+    * fetch: the requests as a function so that they can be reused
+    * pages: with the components the pages were assembled
+    * routes: contains the routing file
+    * store: to manage the states with Zustand, contains the useStore file
+* and the files
+    * App.css
+    * App.jsx
+    * index.js
+    * main.jsx
+* the styles were created with css
+
+<br>
+
+<a id="endpoints"></a>
+### **ENDPOINTS**
+
+* For more information, please consult [To Do List APIS](https://github.com/Orozco23/to-do-list/blob/develop/enterview-gsi-endpoints.md)

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "react-dom": "^19.0.0",
         "react-router-dom": "^7.3.0",
         "react-tooltip": "^5.28.0",
+        "sweetalert2": "^11.17.2",
         "zustand": "^5.0.3"
       },
       "devDependencies": {
@@ -2626,6 +2627,16 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/sweetalert2": {
+      "version": "11.17.2",
+      "resolved": "https://registry.npmjs.org/sweetalert2/-/sweetalert2-11.17.2.tgz",
+      "integrity": "sha512-HKxDr1IyV3Lxr3W6sb61qm/p2epFIEdr5EKwteRFHnIg6f8nHFl2kX++DBVz16Mac+fFiU3hMpjq1L6yE2Ge5w==",
+      "license": "MIT",
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/limonte"
       }
     },
     "node_modules/turbo-stream": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "react-dom": "^19.0.0",
     "react-router-dom": "^7.3.0",
     "react-tooltip": "^5.28.0",
+    "sweetalert2": "^11.17.2",
     "zustand": "^5.0.3"
   },
   "devDependencies": {

--- a/src/App.css
+++ b/src/App.css
@@ -203,7 +203,7 @@
 .filter-selector {
   position: absolute;
   top: 3.5em;
-  left: 0;
+  left: -1.5em;
   list-style: none;
   padding: 8px;
   margin: 0;
@@ -211,11 +211,12 @@
   border-radius: 8px;
   background-color: #585858;
   box-shadow: 0px 4px 8px #404040;
-  width: 6em;
+  width: 9em;
 }
 
 .filter-selector li {
   cursor: pointer;
+  text-align: left;
 }
 
 /* fonts */

--- a/src/App.css
+++ b/src/App.css
@@ -180,6 +180,7 @@
   margin: 1em;  
   font-size: 1em;
   color: #2A2A2A;
+  min-height: 3.4em;
 }
 
 .to-do h4 {
@@ -257,6 +258,7 @@
   text-align: left;
   margin: 1em auto;
   padding: 0 1em;
+  min-height: 3em;
 }
 
 .description {
@@ -267,4 +269,5 @@
   text-align: left;
   margin: 1em auto;
   padding: 0 1em;
+  min-height: 15em;
 }

--- a/src/components/Filter.jsx
+++ b/src/components/Filter.jsx
@@ -1,21 +1,20 @@
 import { useState } from "react"
 import { Tooltip } from "react-tooltip"
 
-export default function Filter() {
+export default function Filter({ filterTasks }) {
     const options = [
-        {icon: <i className="bi bi-trash2 icon-medium primary-color"/>, value: 'created_at'},
-        {icon: <i className="bi bi-pencil icon-medium"/>, value: 'title'},
-        {icon: <i className="bi bi-trash3 icon-medium primary-color"/>, value: 'is_completed'}
+        {icon: <i className="bi bi-arrow-down"/>, value: '-created_at', label: ' created at'},
+        {icon: <i className="bi bi-arrow-up"/>, value: 'created_at', label: ' created at'},
+        {icon: <i className="bi bi-arrow-down"/>, value: '-title', label: ' title'},
+        {icon: <i className="bi bi-arrow-up"/>, value: 'title', label: ' title'},
+        {icon: <i className="bi bi-x"/>, value: 'is_completed', label: "isn't completed"},
+        {icon: <i className="bi bi-check"/>, value: '-is_completed', label: 'is completed'}
     ]
+    const colors = [ 'primary-color', 'secondary-color' ]
+
     const [isOpen, setIsOpen] = useState(false)
-    const [selectedOption, setSelectedOption] = useState('All')
 
     const toggleDropdown = () => setIsOpen(!isOpen)
-
-    const handleSelect = (option) => {
-        setSelectedOption(option)
-        setIsOpen(false)
-    }
 
     return (
         <div className="div-filter">
@@ -35,12 +34,14 @@ export default function Filter() {
                         options.map((option, index) =>
                             <li 
                                 key={index} 
-                                onClick={() => handleSelect(option.value)} 
+                                className={colors[index % 2]}
+                                onClick={() => {
+                                    filterTasks(option.value)
+                                    setIsOpen(false)
+                                }}
                                 name={option.value}
-                                data-tooltip-id="option"
-                                data-tooltip-content={option.value}
                             >
-                                {option.icon}
+                                {option.icon}{option.label}
                             </li>
                         )
                     }

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -2,7 +2,7 @@ import { Tooltip } from 'react-tooltip'
 import { useState } from "react";
 import ModalCreate from './ModalCreate';
 
-export default function Footer() {
+export default function Footer({ setUpdate }) {
     const [isOpen, setIsOpen] = useState(false);
     
     const toggleModal = () => setIsOpen(!isOpen)
@@ -29,6 +29,7 @@ export default function Footer() {
             <ModalCreate
                 isOpen={isOpen}
                 toggleModal={toggleModal}
+                setUpdate={setUpdate}
             />
         </footer>
     )

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -2,7 +2,7 @@ import { Tooltip } from 'react-tooltip'
 import { useState } from "react";
 import ModalCreate from './ModalCreate';
 
-export default function Footer({ setUpdate }) {
+export default function Footer({ setUpdate, next, previous, pages }) {
     const [isOpen, setIsOpen] = useState(false);
     
     const toggleModal = () => setIsOpen(!isOpen)
@@ -13,11 +13,14 @@ export default function Footer({ setUpdate }) {
                 className="bi bi-caret-left icon-larger secondary-color"
                 data-tooltip-id="create"
                 data-tooltip-content="Previous"
+                onClick={previous}
             />
+            <h4>{pages}</h4>
             <i 
                 className="bi bi-caret-right icon-larger secondary-color"
                 data-tooltip-id="create"
                 data-tooltip-content="Next"
+                onClick={next}
             />             
             <i 
                 data-tooltip-id="create"

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,13 +1,15 @@
 import Filter from "./Filter";
 
-export default function Header() {
+export default function Header({ filterTasks }) {
     return (
         <header className="secondary-color">
             <i className="bi bi-list-task icon-large" />
             <h1 className="bebas-neue-regular">
                 List Of TO DO
             </h1>
-            <Filter />                
+            <Filter 
+                filterTasks={filterTasks}
+            />                
         </header>
     )
 }

--- a/src/components/InputTextArea.jsx
+++ b/src/components/InputTextArea.jsx
@@ -1,11 +1,12 @@
-export default function InputTextArea({ maxlength, rows, placeholder, name, id }) {
+export default function InputTextArea({ maxlength, rows, placeholder, id, onChange }) {
     return (
         <textarea 
             maxlength={maxlength} 
             rows={rows}
             placeholder={placeholder}
-            name={name}
+            name={id}
             id={id}
+            onChange={onChange}
         ></textarea>
     )
 }

--- a/src/components/Item.jsx
+++ b/src/components/Item.jsx
@@ -1,18 +1,49 @@
 import { useState } from "react"
 import { Tooltip } from "react-tooltip"
 import ModalRead from "./ModalRead"
+import { deleteTask, updateTask } from "../fetch/Task.fetch"
+import useStore from "../store/useStore"
 
-export default function Item({ color, is_completed, title }) {
+export default function Item({ color, is_completed, id, title, description, created_at, setUpdate }) {
     const icons = ["bi bi-square icon-small-square", "bi bi-check2-square icon-medium"]
     const classes = [ 'item ', 'item strike-out ']
+
+    const { token } = useStore()
 
     const [isOpen, setIsOpen] = useState(false)
     
     const toggleModal = () => setIsOpen(!isOpen)
 
+    const checkItem = async () => {
+        try {
+            await updateTask({
+                token,
+                id
+            })
+            setUpdate()
+        } catch (error) {
+            console.error('Status', error.status)
+        }
+    }
+
+    const deleteItem = async () => {
+        try {
+            await deleteTask({
+                token,
+                id
+            })
+            setUpdate()
+        } catch (error) {
+            console.error('Status', error.status)
+        }
+    }
+
     return (
         <li className={classes[Number(is_completed)] + color + ' to-do'}>
-            <i className={icons[Number(is_completed)]} />
+            <i 
+                className={icons[Number(is_completed)]}
+                onClick={checkItem} 
+            />
             <h4>
                 {title}
             </h4>
@@ -26,13 +57,15 @@ export default function Item({ color, is_completed, title }) {
                 className="bi bi-trash3 icon-small"
                 data-tooltip-id="option"
                 data-tooltip-content="Delete task"
+                onClick={deleteItem}
             />
             <Tooltip id="option" />
             <ModalRead 
                 isOpen={isOpen}
                 toggleModal={toggleModal}
-                title={'0123456789 0123456789 0123456789 0123456789 012345'}
-                description={'0123456789 0123456789 0123456789 0123456789 0123450123456789 0123456789 0123456789 0123456789 0123450123456789 0123456789 0123456789 0123456789 012345 0123456789 0123456789 0123456789 0123456789 012345 0123456789 0123456789 0123456789 0123456789 012345 0123456789 0123456789 0123456789 0123456789 012345'}
+                title={title}
+                description={description}
+                created_at={created_at}
             />
         </li>
     )

--- a/src/components/Item.jsx
+++ b/src/components/Item.jsx
@@ -3,6 +3,7 @@ import { Tooltip } from "react-tooltip"
 import ModalRead from "./ModalRead"
 import { deleteTask, updateTask } from "../fetch/Task.fetch"
 import useStore from "../store/useStore"
+import Swal from "sweetalert2"
 
 export default function Item({ color, is_completed, id, title, description, created_at, setUpdate }) {
     const icons = ["bi bi-square icon-small-square", "bi bi-check2-square icon-medium"]
@@ -26,12 +27,40 @@ export default function Item({ color, is_completed, id, title, description, crea
         }
     }
 
+    const confirmDelete = () => {
+        Swal.fire({
+            title: "Are you sure?",
+            text: "You won't be able to revert this!",
+            icon: "warning",
+            showCancelButton: true,
+            confirmButtonColor: '#F76C6A',
+            cancelButtonColor: '#F79E89',
+            background: '#2A2A2A',
+            color: '#F79E89',
+            iconColor: '#F76C6A',
+            confirmButtonText: "Yes, delete it!"
+          }).then((result) => {
+            if (result.isConfirmed) {
+                deleteItem()
+            }
+          })
+    }
+
     const deleteItem = async () => {
         try {
             await deleteTask({
                 token,
                 id
             })
+            Swal.fire({
+                title: "Deleted!",
+                text: "Your task has been deleted.",
+                icon: "success",
+                confirmButtonColor: "#F76C6A",
+                background: '#2A2A2A',
+                color: '#F79E89',
+                iconColor: '#F76C6A'
+              })
             setUpdate()
         } catch (error) {
             console.error('Status', error.status)
@@ -57,7 +86,7 @@ export default function Item({ color, is_completed, id, title, description, crea
                 className="bi bi-trash3 icon-small"
                 data-tooltip-id="option"
                 data-tooltip-content="Delete task"
-                onClick={deleteItem}
+                onClick={confirmDelete}
             />
             <Tooltip id="option" />
             <ModalRead 

--- a/src/components/List.jsx
+++ b/src/components/List.jsx
@@ -1,13 +1,17 @@
 import Item from "./Item"
 
-export default function List({ tasks }) {
+export default function List({ tasks, setUpdate }) {
     const colors = [ 'secondary-background', 'primary-background' ]
     const items = tasks.map((task, index) => 
         <Item
             key={index}
             color={colors[index % 2]}
             is_completed={task.is_completed}
+            id={task.id}
             title={task.title}
+            description={task.description}
+            created_at={task.created_at}
+            setUpdate={setUpdate}
         />);
 
     return (

--- a/src/components/LogOut.jsx
+++ b/src/components/LogOut.jsx
@@ -1,6 +1,17 @@
 import { Tooltip } from "react-tooltip";
+import useStore from "../store/useStore";
+import { useNavigate } from "react-router-dom";
 
 export default function LogOut() {
+    
+    const { removeAll } = useStore()
+    const navigate = useNavigate()
+
+    const removeStates = () => {
+        removeAll()
+        navigate('/')
+    }
+
     return (
         <div className="grid primary-color">
             <h2>TO DO LIST</h2>
@@ -8,6 +19,7 @@ export default function LogOut() {
                 className="bi bi-door-closed icon-medium"
                 data-tooltip-id="logout"
                 data-tooltip-content="Log Out"
+                onClick={removeStates}
             />
             <Tooltip id="logout" />
         </div>

--- a/src/components/ModalCreate.jsx
+++ b/src/components/ModalCreate.jsx
@@ -3,6 +3,7 @@ import useStore from "../store/useStore";
 import Button from "./Button";
 import InputTextArea from "./InputTextArea";
 import { createTask } from "../fetch/Task.fetch";
+import Swal from "sweetalert2";
 
 export default function ModalCreate({ isOpen, toggleModal, setUpdate }) {
     const { user_email, token } = useStore()
@@ -30,7 +31,16 @@ export default function ModalCreate({ isOpen, toggleModal, setUpdate }) {
                 console.error('Status', error.status)
             }
         } else {
-            console.error('The title field may not be blank.')
+            Swal.fire({
+                title: 'Error!',
+                text: 'The title may not be blank',
+                icon: 'error',
+                confirmButtonText: 'Ok',
+                confirmButtonColor: '#F76C6A',
+                background: '#2A2A2A',
+                color: '#F79E89',
+                iconColor: '#F76C6A'
+            })
         }
     }
 

--- a/src/components/ModalCreate.jsx
+++ b/src/components/ModalCreate.jsx
@@ -1,7 +1,39 @@
+import { useState } from "react";
+import useStore from "../store/useStore";
 import Button from "./Button";
 import InputTextArea from "./InputTextArea";
+import { createTask } from "../fetch/Task.fetch";
 
-export default function ModalCreate({ isOpen, toggleModal }) {
+export default function ModalCreate({ isOpen, toggleModal, setUpdate }) {
+    const { user_email, token } = useStore()
+
+    const [title, setTitle] = useState('')
+    const [description, setDescription] = useState(null)
+
+    const changeTitle = (e) => setTitle(e.target.value)
+    const changeDescription = (e) => setDescription(e.target.value)
+
+    const addTask = async () => {
+        if (title.length > 0) {
+            try {
+                await createTask({
+                    user_email,
+                    token,
+                    title,
+                    description
+                })
+                setTitle('')
+                setDescription(null)
+                toggleModal()
+                setUpdate()
+            } catch (error) {
+                console.error('Status', error.status)
+            }
+        } else {
+            console.error('The title field may not be blank.')
+        }
+    }
+
     return (
         <div>  
             {isOpen && (
@@ -10,17 +42,18 @@ export default function ModalCreate({ isOpen, toggleModal }) {
                         maxlength={50}
                         rows={3}
                         placeholder='Title'
-                        name='title'
                         id='title'
+                        onChange={changeTitle}
                     />
                     <InputTextArea
                         maxlength={255}
                         rows={10}
                         placeholder='Description'
-                        name='description'
                         id='description'
+                        onChange={changeDescription}
                     />
                     <Button 
+                        event={addTask}
                         type='submit'
                         text='Add'
                         color='secondary-background' 

--- a/src/components/ModalRead.jsx
+++ b/src/components/ModalRead.jsx
@@ -1,12 +1,13 @@
 import Button from "./Button";
 
-export default function ModalRead({ isOpen, toggleModal, title, description }) {
+export default function ModalRead({ isOpen, toggleModal, title, description, created_at }) {
     return (
         <div>  
             {isOpen && (
                 <div className="modal-panel">
                     <p className="title">{title}</p>
                     <p className="description">{description}</p>
+                    <h5>{created_at.slice(0,10)}</h5>
                     <Button 
                         event={toggleModal}
                         type='button'

--- a/src/fetch/Task.fetch.js
+++ b/src/fetch/Task.fetch.js
@@ -1,8 +1,7 @@
 const apiUrl = import.meta.env.VITE_API_BASE_URL
-const user_email = 'correos@prueba.com'
 
 // create a task
-export const createTask = async ({ token, description, title }) => {
+export const createTask = async ({ user_email, token, description, title }) => {
     try {
         const response = await fetch(
             `${apiUrl}tasks/create`,

--- a/src/index.css
+++ b/src/index.css
@@ -106,6 +106,16 @@ textarea:focus-visible {
   outline: 10px auto -webkit-focus-ring-color;
 }
 
+textarea::-webkit-scrollbar {
+  width: 0.5em;
+}
+
+textarea::-webkit-scrollbar-thumb {
+  background-color: #F76C6A;
+  outline: 1px solid #9e9e9e;
+  border-radius: 16px;
+}
+
 header {
   display: grid;
   grid-template-columns: 1fr 5fr 1fr;

--- a/src/index.css
+++ b/src/index.css
@@ -136,14 +136,20 @@ div span {
 
 footer {
   display: grid;
-  grid-template-columns: 2fr 2fr 5fr;
+  grid-template-columns: 2fr 1fr 2fr 5fr;
   gap: 5px;
   grid-auto-rows: auto;
+  padding: 0 1.5em;
 }
 
 footer .right {
   text-align: right;
-  padding-right: 1.5em;
+  padding-right: 1em;
+}
+
+footer h4 {
+  place-content: center;
+  color: #F79E89;
 }
 
 

--- a/src/pages/ListOfToDo.jsx
+++ b/src/pages/ListOfToDo.jsx
@@ -35,11 +35,26 @@ export default function ListOfToDo() {
         }
     },[token, update])
 
+    const filterTasks = async (order) => {
+        try {
+            let response = await getList({
+                token,
+                limit: 5,
+                order,
+                page: 1
+            })
+            setTasks(response.data)
+        } catch (error) {
+            console.error('Status', error.status)
+        }
+    }
 
     return (
         <>
             <LogOut />
-            <Header />
+            <Header
+                filterTasks={filterTasks}
+            />
             <List 
                 tasks={tasks}
                 setUpdate={setUpdate}

--- a/src/pages/ListOfToDo.jsx
+++ b/src/pages/ListOfToDo.jsx
@@ -12,6 +12,12 @@ export default function ListOfToDo() {
 
     const [tasks, setTasks] = useState([])
     const [update, isUpdate] = useState(false)
+    const [selectedOrder, setSelectedOrder] = useState('-created_at')
+    const [pagesNumber, setPagesNumber] = useState(0)
+    const [currentPage, setCurrentPage] = useState(1)
+
+    // items
+    const limit = 5
 
     const setUpdate = () => isUpdate(!update)
 
@@ -20,11 +26,13 @@ export default function ListOfToDo() {
             try {
                 let response = await getList({
                     token,
-                    limit: 5,
+                    limit,
                     order: '-created_at',
                     page: 1
                 })
                 setTasks(response.data)
+                setPagesNumber(response.meta.pages)
+                setCurrentPage(1)
             } catch (error) {
                 console.error('Status', error.status)
             }
@@ -39,11 +47,47 @@ export default function ListOfToDo() {
         try {
             let response = await getList({
                 token,
-                limit: 5,
+                limit,
                 order,
                 page: 1
             })
             setTasks(response.data)
+            setSelectedOrder(order)
+            setCurrentPage(1)
+            setPagesNumber(response.meta.pages)
+        } catch (error) {
+            console.error('Status', error.status)
+        }
+    }
+    
+    const goToNextPage = async () => {
+        if (currentPage === pagesNumber) return
+        try {
+            let response = await getList({
+                token,
+                limit,
+                order: selectedOrder,
+                page: currentPage + 1
+            })
+            setTasks(response.data)
+            setCurrentPage((currentPage) => currentPage + 1)
+            setPagesNumber(response.meta.pages)
+        } catch (error) {
+            console.error('Status', error.status)
+        }
+    }
+    const goToPreviousPage = async () => {
+        if (currentPage === 1) return
+        try {
+            let response = await getList({
+                token,
+                limit,
+                order: selectedOrder,
+                page: currentPage - 1
+            })
+            setTasks(response.data)
+            setCurrentPage((currentPage) => currentPage - 1)
+            setPagesNumber(response.meta.pages)
         } catch (error) {
             console.error('Status', error.status)
         }
@@ -61,6 +105,9 @@ export default function ListOfToDo() {
             />
             <Footer 
                 setUpdate={setUpdate}
+                next={goToNextPage}
+                previous={goToPreviousPage}
+                pages={currentPage + ' of ' + pagesNumber}
             />
         </>
     )

--- a/src/pages/ListOfToDo.jsx
+++ b/src/pages/ListOfToDo.jsx
@@ -1,26 +1,52 @@
+import { useEffect, useState } from "react"
 import Footer from "../components/Footer"
 import Header from "../components/header"
 import List from "../components/List"
 import LogOut from "../components/LogOut"
+import { getList } from "../fetch/Task.fetch"
+import useStore from "../store/useStore"
 
 export default function ListOfToDo() {
-    const tasks = [
-        {title: 'do la sol', is_completed: false},
-        {title: 'finish', is_completed: true},
-        {title: '0123456789 0123456789 0123456789 0123456789 012345', is_completed: true},
-        {title: 'buy', is_completed: false},
-        {title: 'abcde fghijk lmno pqrstu vwxyz', is_completed: false},
-        {title: 'abcdef ghij klmnop qrst uvwxyz', is_completed: true}
-    ]
+
+    const { token } = useStore()
+
+    const [tasks, setTasks] = useState([])
+    const [update, isUpdate] = useState(false)
+
+    const setUpdate = () => isUpdate(!update)
+
+    useEffect(() =>{
+        const getTasks = async () => {
+            try {
+                let response = await getList({
+                    token,
+                    limit: 5,
+                    order: '-created_at',
+                    page: 1
+                })
+                setTasks(response.data)
+            } catch (error) {
+                console.error('Status', error.status)
+            }
+        }
+
+        if (token) {
+            getTasks()
+        }
+    },[token, update])
+
 
     return (
         <>
             <LogOut />
             <Header />
             <List 
-                tasks = {tasks}
+                tasks={tasks}
+                setUpdate={setUpdate}
             />
-            <Footer />
+            <Footer 
+                setUpdate={setUpdate}
+            />
         </>
     )
 }

--- a/src/pages/LogIn.jsx
+++ b/src/pages/LogIn.jsx
@@ -5,7 +5,7 @@ import { logIn } from '../fetch/LogIn.fetch';
 import { useState } from 'react';
 import useStore from '../store/useStore';
 import { useNavigate } from 'react-router-dom';
-
+import Swal from 'sweetalert2'
 
 function LogIn() {
 
@@ -27,7 +27,16 @@ function LogIn() {
             console.error('Status', error.status)
         }
     } else {
-        console.error('invalid email')
+        Swal.fire({
+          title: 'Error!',
+          text: 'Invalid email',
+          icon: 'error',
+          confirmButtonText: 'Ok',
+          confirmButtonColor: '#F76C6A',
+          background: '#2A2A2A',
+          color: '#F79E89',
+          iconColor: '#F76C6A'
+        })
     }
   }
 


### PR DESCRIPTION
Added crud for tasks, functionality for filter and pagination, alerts to show errors and confirmation

Request 

```
try {
    let response = await getList({
        token,
        limit,
        order: selectedOrder,
        page: currentPage + 1
    })
    setTasks(response.data)
    setCurrentPage((currentPage) => currentPage + 1)
    setPagesNumber(response.meta.pages)
} catch (error) {
    console.error('Status', error.status)
}
```

Filter

![image](https://github.com/user-attachments/assets/79b314c5-866e-4553-ad23-3c5d8f1b9345)

For alerts, sweetalert2 was used

Error alert
![image](https://github.com/user-attachments/assets/ebe1ef22-d73d-4a02-80eb-9f58c2dc3eab)

Confirmation alert
![image](https://github.com/user-attachments/assets/6ecd9e59-89bf-41e8-b6a3-f9637a07fe16)

Success alert
![image](https://github.com/user-attachments/assets/07554a5f-ca12-4b47-a391-3fc140111075)

